### PR TITLE
Fix createTerminal signture (changed in 1.6 code)

### DIFF
--- a/Fable.Import.VSCode.fs
+++ b/Fable.Import.VSCode.fs
@@ -552,7 +552,7 @@ module vscode =
         static member setStatusBarMessage(text: string, hideAfterTimeout: float): Disposable = failwith "JS only"
         static member setStatusBarMessage(text: string, hideWhenDone: Promise<obj>): Disposable = failwith "JS only"
         static member createStatusBarItem(?alignment: StatusBarAlignment, ?priority: float): StatusBarItem = failwith "JS only"
-        static member createTerminal(?name : string, ?shellName : string, ?shellArgs : string) : Terminal = failwith "JS only"
+        static member createTerminal(?name : string, ?shellPath : string, ?shellArgs : string[]) : Terminal = failwith "JS only"
 
     type [<Import("workspace","vscode")>] workspace =
         static member rootPath with get(): string = failwith "JS only" and set(v: string): unit = failwith "JS only"


### PR DESCRIPTION
Cześć Krzysztof,

I was fixing regressing related to latest terminal refactoring in  2.6.8 and I was getting run-time error in @code related to the createTerminal method and it's parameters. 
So I was passing additional parameters in form of string (as it is in current version), but it failed - and the problem is that createTerminal has different signature in the current 1.6 release. 
So this PR fixes it and will allow me to finish PR for Ionide-fsharp which brings back FSI extra parameters. 

Here is the link to the method signature: 
https://github.com/Microsoft/vscode/blob/760b880ee486359ef1aa0e398d5056c6055d87f0/src/vs/vscode.d.ts#L3570
