### PR TITLE
Extend Terminal bindings

### DIFF
--- a/Fable.Import.VSCode.fs
+++ b/Fable.Import.VSCode.fs
@@ -482,6 +482,7 @@ module vscode =
         abstract hide : unit -> unit
         abstract show : ?prserveFocus : bool -> unit
         abstract sendText : text : string * ?addNewLine : bool -> unit
+        abstract processId: Promise<int> with get
 
     and Extension<'T> =
         abstract id: string with get, set

--- a/Fable.Import.VSCode.fs
+++ b/Fable.Import.VSCode.fs
@@ -554,6 +554,7 @@ module vscode =
         static member setStatusBarMessage(text: string, hideWhenDone: Promise<obj>): Disposable = failwith "JS only"
         static member createStatusBarItem(?alignment: StatusBarAlignment, ?priority: float): StatusBarItem = failwith "JS only"
         static member createTerminal(?name : string, ?shellPath : string, ?shellArgs : string[]) : Terminal = failwith "JS only"
+        static member onDidCloseTerminal with get(): Event<Terminal> = failwith "JS only"
 
     type [<Import("workspace","vscode")>] workspace =
         static member rootPath with get(): string = failwith "JS only" and set(v: string): unit = failwith "JS only"


### PR DESCRIPTION
Hi,

The aim of this PR is to add processId promise along with onDidCloseTerminal to improve FSI terminal handling [Ionide - #198](https://github.com/ionide/ionide-vscode-fsharp/pull/198).

Thanks!
