### PR TITLE
Theme color & few other things

### DIFF
--- a/Fable.Import.VSCode.fs
+++ b/Fable.Import.VSCode.fs
@@ -14,7 +14,6 @@ module vscode =
 
 
     and [<Import("EventEmitter", "vscode")>] EventEmitter<'T>() =
-
         member __.addListener(``event``: string, listener: Function): NodeJS.EventEmitter = failwith "JS only"
         member __.on(``event``: string, listener: Function): NodeJS.EventEmitter = failwith "JS only"
         member __.once(``event``: string, listener: Function): NodeJS.EventEmitter = failwith "JS only"
@@ -88,9 +87,20 @@ module vscode =
         member __.active with get(): Position = failwith "JS only" and set(v: Position): unit = failwith "JS only"
         member __.isReversed with get(): bool = failwith "JS only" and set(v: bool): unit = failwith "JS only"
 
+    /// Represents sources that can cause selection change events.
+    and TextEditorSelectionChangeKind =
+        /// Selection changed due to typing in the editor.
+        | Keyboard = 1
+        /// Selection change due to clicking in the editor.
+        | Mouse = 2
+        /// Selection changed because a command ran.
+        | Command = 3
+
     and TextEditorSelectionChangeEvent =
         abstract textEditor: TextEditor with get, set
         abstract selections: ResizeArray<Selection> with get, set
+        /// The change kind which has triggered this event.
+        abstract kind: TextEditorSelectionChangeKind option with get, set
 
     and TextEditorOptionsChangeEvent =
         abstract textEditor: TextEditor with get, set
@@ -115,25 +125,41 @@ module vscode =
         | Right = 4
         | Full = 7
 
+    and DecorationRangeBehavior =
+        /// The decoration's range will widen when edits occur at the start or end.
+        | OpenOpen = 0
+        /// The decoration's range will not widen when edits occur at the start of end.
+        | ClosedClosed = 1
+        /// The decoration's range will widen when edits occur at the start, but not at the end.
+        | OpenClosed = 2
+        /// The decoration's range will widen when edits occur at the end, but not at the start.
+        | ClosedOpen = 3
+
+    and [<Import("ThemeColor","vscode")>] ThemeColor(id: string) =
+        class end
+
     and ThemableDecorationRenderOptions =
-        abstract backgroundColor: string option with get, set
-        abstract outlineColor: string option with get, set
+        abstract backgroundColor: U2<string, ThemeColor> option with get, set
+        abstract outlineColor: U2<string, ThemeColor> option with get, set
         abstract outlineStyle: string option with get, set
         abstract outlineWidth: string option with get, set
-        abstract borderColor: string option with get, set
+        abstract borderColor: U2<string, ThemeColor> option with get, set
         abstract borderRadius: string option with get, set
         abstract borderSpacing: string option with get, set
         abstract borderStyle: string option with get, set
         abstract borderWidth: string option with get, set
         abstract textDecoration: string option with get, set
         abstract cursor: string option with get, set
-        abstract color: string option with get, set
+        abstract color: U2<string, ThemeColor> option with get, set
         abstract gutterIconPath: string option with get, set
-        abstract overviewRulerColor: string option with get, set
+        abstract overviewRulerColor: U2<string, ThemeColor> option with get, set
 
     and DecorationRenderOptions =
         inherit ThemableDecorationRenderOptions
         abstract isWholeLine: bool option with get, set
+        /// Customize the growing behavior of the decoration when edits occur at the edges of the decoration's range.
+        /// Defaults to `DecorationRangeBehavior.OpenOpen`.
+        abstract rangeBehavior: DecorationRangeBehavior option with get, set
         abstract overviewRulerLane: OverviewRulerLane option with get, set
         abstract light: ThemableDecorationRenderOptions option with get, set
         abstract dark: ThemableDecorationRenderOptions option with get, set
@@ -147,13 +173,13 @@ module vscode =
         /// CSS styling property that will be applied to the decoration attachment.
         abstract border: string option with get, set
         /// CSS styling property that will be applied to text enclosed by a decoration.
-        abstract borderColor: string option with get, set
+        abstract borderColor: U2<string, ThemeColor> option with get, set
         /// CSS styling property that will be applied to the decoration attachment.
         abstract textDecoration: string option with get, set
         /// CSS styling property that will be applied to the decoration attachment.
-        abstract color: string option with get, set
+        abstract color: U2<string, ThemeColor> option with get, set
         /// CSS styling property that will be applied to the decoration attachment.
-        abstract backgroundColor: string option with get, set
+        abstract backgroundColor: U2<string, ThemeColor> option with get, set
         /// CSS styling property that will be applied to the decoration attachment.
         abstract margin: string option with get, set
         /// CSS styling property that will be applied to the decoration attachment.

--- a/Fable.Import.VSCode.fs
+++ b/Fable.Import.VSCode.fs
@@ -561,8 +561,10 @@ module vscode =
         abstract globalState: Memento with get, set
         abstract extensionPath: string with get, set
         abstract asAbsolutePath: relativePath: string -> string
+        abstract storagePath: string option with get, set
 
     and Memento =
+        abstract get<'T> : key: string -> 'T option
         abstract get: key: string * ?defaultValue: 'T -> 'T
         abstract update: key: string * value: obj -> Promise<unit>
 

--- a/Helpers.fs
+++ b/Helpers.fs
@@ -92,7 +92,7 @@ module Promise =
     let onFail (a : obj -> unit) (pr : Promise<'T>) : Promise<'T> =
         pr.catch (unbox<Func<obj, U2<'T, PromiseLike<'T>>>> (fun reason -> a reason |> ignore; reject reason))
 
-    let all (prs : Promise<'T> seq) =
+    let all (prs : Promise<'T> seq): JS.Promise<ResizeArray<'T>> =
         Promise.all (unbox prs)
 
     let empty<'T> = lift (unbox<'T>null)

--- a/package.json
+++ b/package.json
@@ -23,12 +23,12 @@
   "homepage": "https://github.com/ionide/ionide-vscode-helpers#readme",
   "dependencies": {
     "axios": "^0.13.1",
-    "fable-core": "*"
+    "fable-core": "0.6.x"
   },
   "scripts": {
     "build": "fable ./Ionide.VSCode.Helpers.fsproj -s -o ./release/ -m commonjs --verbose"
   },
   "devDependencies": {
-    "fable-compiler": "*"
+    "fable-compiler": "0.6.x"
   }
 }


### PR DESCRIPTION
* Add the possibility to use ThemeColor in decorations instead of hardcoded colors
* Add a few other details around decorations (DecorationRangeBehavior )
* Use a better type for Promise.all
* Pin Fable to 0.6.x (Otherwise it get 0.7 from npm and the signature for exec is different)

Regarding the last one, would you be opposed to an update to Fable 1.x ? I suspect it's not easy but I've hit some bugs that I believe are fixed now.