### PR TITLE
exclude null and empty string produces by split

### DIFF
--- a/src/Helpers.fs
+++ b/src/Helpers.fs
@@ -137,6 +137,7 @@ module Process =
                 else
                     if e.StartsWith "\"" &&  e.EndsWith "\"" then None, e.Replace("\"", "")::acc
                     elif e.StartsWith "\"" then Some e, acc
+                    elif String.IsNullOrEmpty e then None, acc
                     else None, e::acc
             ) (None,[])
             |> snd


### PR DESCRIPTION
should release with https://github.com/ionide/ionide-vscode-fsharp/pull/647

with some case like the cmd is : `dotnet run -p xxxx.fsproj --             --debug`

split will generate some `""` strings to dotnet cli commandline, and this will produce some exception.

```shell
lust@lust ~/g/temp> dotnet run -p temp.fsproj  -- "" --debug
System.IndexOutOfRangeException: Index was outside the bounds of the array.
   at System.String.get_Chars(Int32 index)
   at Microsoft.DotNet.Cli.CommandLine.StringExtensions.HasPrefix(String arg)
   at Microsoft.DotNet.Cli.CommandLine.StringExtensions.<Lex>d__7.MoveNext()
   at System.Collections.Generic.EnumerableHelpers.ToArray[T](IEnumerable`1 source, Int32& length)
   at System.Collections.Generic.Queue`1..ctor(IEnumerable`1 collection)
   at Microsoft.DotNet.Cli.CommandLine.Parser.Parse(IReadOnlyCollection`1 rawArgs, Boolean isProgressive)
   at Microsoft.DotNet.Cli.CommandLine.Parser.Parse(String[] args)
   at Microsoft.DotNet.Cli.ParserExtensions.ParseFrom(Parser parser, String context, String[] args)
   at Microsoft.DotNet.Cli.Program.ProcessArgs(String[] args, ITelemetry telemetryClient)
   at Microsoft.DotNet.Cli.Program.Main(String[] args)
lust@lust ~/g/temp> 

```