### PR TITLE
Add SnippetString option for CompletionItem.insertText

### DIFF
--- a/src/Fable.Import.VSCode.fs
+++ b/src/Fable.Import.VSCode.fs
@@ -460,10 +460,12 @@ module vscode =
         member __.documentation with get(): U2<string, MarkdownString> = failwith "JS only" and set(v: U2<string, MarkdownString>): unit = failwith "JS only"
         member __.sortText with get(): string = failwith "JS only" and set(v: string): unit = failwith "JS only"
         member __.filterText with get(): string = failwith "JS only" and set(v: string): unit = failwith "JS only"
-        member __.insertText with get(): string = failwith "JS only" and set(v: string): unit = failwith "JS only"
+        member __.insertText with get(): U2<string, SnippetString> = failwith "JS only" and set(v: U2<string, SnippetString>): unit = failwith "JS only"
         member __.textEdit with get(): TextEdit = failwith "JS only" and set(v: TextEdit): unit = failwith "JS only"
         member __.additionalTextEdits with get(): TextEdit[] = failwith "JS only" and set(v: TextEdit[]): unit = failwith "JS only"
 
+    and [<Import("SnippetString","vscode")>] SnippetString(value: string) =
+        member __.value with get(): string = failwith "JS only" and set(v: string): unit = failwith "JS only"
 
     and CompletionItemProvider =
         abstract provideCompletionItems: document: TextDocument * position: Position * token: CancellationToken -> U2<ResizeArray<CompletionItem>, Promise<ResizeArray<CompletionItem>>>


### PR DESCRIPTION
Hello,

I'm trying to create a vscode extension (https://github.com/TypedUseCase/tuc-extension), which is _a bit_ similar as Ionide and since it is my first extension, I'm highly inspired by Ionide itself. 

My extension is for a custom language which uses F# types as a domain specification, and uses those types in use case (typed-use-case -> https://typedusecase.github.io/).

For now, I'm trying to switch from this type script code https://github.com/TypedUseCase/tuc-extension/blob/master/src/extension.ts to the F# code and I need a `SnippetString` for that - I tried to change imported ionide-vscode-helpers locally and use it here: https://github.com/MortalFlesh/tuc-extension/blob/feature/use-fable-by-ionide-5/src/Components/KeywordsCompletion.fs#L73 and it worked (without a `SnippetString` class, it is just a string, and after vs code inserts a string, it stays the same - but with `SnippetString`, it gets a focus and _must_ be changed.

I'm not sure, if I need to add anything else to this PR - I could, but please let me know, what :)

Thank you (_for whole Ionide!_)