### PR TITLE
fix: signature of TreeDataProvider.getChildren

### DIFF
--- a/src/Fable.Import.VSCode.fs
+++ b/src/Fable.Import.VSCode.fs
@@ -633,7 +633,7 @@ module vscode =
     and TreeDataProvider<'T> =
         abstract onDidChangeTreeData: Event<'T option> with get
         abstract getTreeItem: 'T -> TreeItem
-        abstract getChildren: 'T -> ResizeArray<'T>
+        abstract getChildren: 'T option -> ResizeArray<'T>
         abstract getParent: ('T -> 'T option) option with get
 
     and TreeIconPath =


### PR DESCRIPTION
With current signature`getChildren` for tree root is not represented
<img width="812" alt="Tree_View_API___Visual_Studio_Code_Extension_API" src="https://user-images.githubusercontent.com/1197905/111083266-f1565200-850c-11eb-9dd9-98570c5e6a71.png">
