### PR TITLE
fix: signature of provideTextDocumentContent

### DIFF
--- a/src/Fable.Import.VSCode.fs
+++ b/src/Fable.Import.VSCode.fs
@@ -621,7 +621,7 @@ module vscode =
         abstract contentChanges: ResizeArray<TextDocumentContentChangeEvent> with get, set
 
     and TextDocumentContentProvider =
-        abstract provideTextDocumentContent : uri: Uri -> string
+        abstract provideTextDocumentContent : uri: Uri -> Promise<string>
 
     and [<Import("DocumentLink","vscode")>] DocumentLink(range : Range, target: Uri) =
         member __.target with get(): Uri = failwith "JS only" and set(v: Uri): unit = failwith "JS only"

--- a/src/Fable.Import.VSCode.fs
+++ b/src/Fable.Import.VSCode.fs
@@ -621,7 +621,7 @@ module vscode =
         abstract contentChanges: ResizeArray<TextDocumentContentChangeEvent> with get, set
 
     and TextDocumentContentProvider =
-        abstract provideTextDocumentContent : uri: Uri -> Promise<string>
+        abstract provideTextDocumentContent : uri: Uri -> U2<string, Promise<string>>
 
     and [<Import("DocumentLink","vscode")>] DocumentLink(range : Range, target: Uri) =
         member __.target with get(): Uri = failwith "JS only" and set(v: Uri): unit = failwith "JS only"


### PR DESCRIPTION
According to docs 
https://code.visualstudio.com/api/references/vscode-api#TextDocumentContentProvider

`TextDocumentContentProvider.provideTextDocumentContent` return `ProviderResult<string>`
```ts
provideTextDocumentContent(uri: Uri, token: CancellationToken): ProviderResult<string>
```
and `ProviderResult<string>` is defined as 
```ts
ProviderResult: T | undefined | null | Thenable<T | undefined | null>
```

Current signature does not allow to request text content asynchronously from the server.