### PR TITLE
fix: add ctor to ThemeIcon

### DIFF
--- a/src/Fable.Import.VSCode.fs
+++ b/src/Fable.Import.VSCode.fs
@@ -640,7 +640,7 @@ module vscode =
         abstract light: U3<string, Uri, ThemeIcon> with get, set
         abstract dark: U3<string, Uri, ThemeIcon> with get, set
 
-    and [<Import("ThemeIcon","vscode")>] ThemeIcon =
+    and [<Import("ThemeIcon","vscode")>] ThemeIcon(id: string) =
         static member File with get(): ThemeIcon = failwith "JS only"
         static member Folder with get(): ThemeIcon = failwith "JS only"
         member __.id with get(): string = jsNative


### PR DESCRIPTION
According to docs `ThemeIcon` has ctor that accept `id`
https://code.visualstudio.com/api/references/vscode-api#ThemeIcon

<img width="592" alt="image" src="https://user-images.githubusercontent.com/1197905/111906242-e68d4700-8a4f-11eb-975b-1dfc83c1931d.png">


this fix allow to use icons from [Icon Listing](https://code.visualstudio.com/api/references/icons-in-labels#icon-listing) like this `vscode.ThemeIcon("file-binary")`