### PR TITLE
Fix output race condition in Process.exec

### DIFF
--- a/src/Helpers.fs
+++ b/src/Helpers.fs
@@ -47,6 +47,10 @@ module Process =
     let isWin () = platform = "win32"
     let isMono () = platform <> "win32"
 
+    let onClose (f : int option -> string option -> unit) (proc : ChildProcess) =
+        proc.on("close", f) |> ignore
+        proc
+
     let onExit (f : int option -> string option -> unit) (proc : ChildProcess) =
         proc.on("exit", f) |> ignore
         proc
@@ -154,7 +158,7 @@ module Process =
             |> onOutput (fun e -> stdout.Add(string e))
             |> onError (fun e -> error <- Some e)
             |> onErrorOutput (fun e -> stderr.Add(string e))
-            |> onExit (fun code signal ->
+            |> onClose (fun code signal ->
                 resolve (unbox error, String.concat "\n" stdout, String.concat "\n" stderr)
             )
             |> ignore


### PR DESCRIPTION
I encountered an issue when starting projects up. Others have had the problem as well, so I fixed it in this pull request.

It has to do with the definition of `Process.exec`, which the Ionide extension uses to find the `dotnet` executable.

Per the [documentation](https://nodejs.org/api/child_process.html) of `child_process`:
>The 'close' event is emitted after a process has ended and the stdio streams of a child process have been closed. This is distinct from the ['exit'](https://nodejs.org/api/child_process.html#event-exit) event, since multiple processes might share the same stdio streams. The 'close' event will always emit after ['exit'](https://nodejs.org/api/child_process.html#event-exit) was already emitted, or ['error'](https://nodejs.org/api/child_process.html#event-error) if the child failed to spawn.

>The 'exit' event is emitted after the child process ends. If the process exited, code is the final exit code of the process, otherwise null. If the process terminated due to receipt of a signal, signal is the string name of the signal, otherwise null. One of the two will always be non-null.
>
> When the 'exit' event is triggered, child process stdio streams might still be open.

Thus, because the output of `Process.exec` relies on the accumulated output of the child process, the promise must relolve on the `close` event instead of the `exit` event.

Fixes https://github.com/ionide/ionide-vscode-fsharp/issues/1712
Fixes https://github.com/ionide/ionide-vscode-fsharp/issues/1686